### PR TITLE
Update DMAElementGenerator.php

### DIFF
--- a/src/dma_elementgenerator/DMAElementGenerator.php
+++ b/src/dma_elementgenerator/DMAElementGenerator.php
@@ -709,7 +709,7 @@ class DMAElementGenerator extends Frontend
             $arrFieldData  = &$objTemplate->data[$strName];
             $arrImagePaths = [];
             
-            if ($arrFieldData['value']) {
+            if ($arrFieldData['value'] && is_array($arrFieldData['value'])) {
                 foreach ($arrFieldData['value'] as &$arrValue) {
                     $objFile = \FilesModel::findByUuid($arrValue['raw']);
                     


### PR DESCRIPTION
Prevent the system for triggering an warning if the image doesn't exsist on the filesystem.

This small fix sould prevent the system to trigger a warning, because on the line 712 + 713 we didn't have all the time an array. If the image doesn't exsist anymore on the filesystem, you will get the UUID for $arrFieldData['value'] and not an array. So you have to check first if you have an array. 

The last question is, what should we do with the dead files?